### PR TITLE
Add initial support for on-the-board openOCD+GDB. ELF loading and starting works, with Digilent JTAG Adapter.

### DIFF
--- a/mtkcpu/cli/top.py
+++ b/mtkcpu/cli/top.py
@@ -41,7 +41,7 @@ def get_board_cpu(elf_path : Optional[Path] = None):
 
 def get_platform() -> Platform:
     from amaranth_boards.icebreaker import ICEBreakerPlatform
-    from amaranth.build.dsl import Resource, Pins, Attrs
+    from amaranth.build.dsl import Resource, Pins, Attrs, Subsignal
     
     platform = ICEBreakerPlatform()
 
@@ -56,13 +56,13 @@ def get_platform() -> Platform:
         Resource(
             "debug",
             0,
-            Pins(
-                "1 2 3 4 7 8 9 10 ",
-                dir="o",
-                conn=("pmod", 1)),
-                Attrs(IO_STANDARD="SB_LVCMOS")
+            Subsignal("tms", Pins("1", dir="i", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
+            Subsignal("tdi", Pins("2", dir="i", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
+            Subsignal("tdo", Pins("3", dir="o", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
+            Subsignal("tck", Pins("4", dir="i", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
             ),
-    ])
+        ]
+    )
 
     # TMS - white - 1
     # TDI - gray - 2

--- a/mtkcpu/cli/top.py
+++ b/mtkcpu/cli/top.py
@@ -60,6 +60,7 @@ def get_platform() -> Platform:
             Subsignal("tdi", Pins("2", dir="i", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
             Subsignal("tdo", Pins("3", dir="o", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
             Subsignal("tck", Pins("4", dir="i", conn=("pmod", 1)), Attrs(IO_STANDARD="SB_LVCMOS")),
+            Attrs(IO_STANDARD="SB_LVCMOS"),
             ),
         ]
     )

--- a/mtkcpu/cli/top.py
+++ b/mtkcpu/cli/top.py
@@ -65,51 +65,12 @@ def get_platform() -> Platform:
         ]
     )
 
-    # TMS - white - 1
-    # TDI - gray - 2
-    # TDO - purple - 3
-    # TCK - blue - 4
-
     return platform
 
-from amaranth import *
-class M(Elaboratable):
-    def elaborate(self, platform):
-        m = Module()
-        comb, sync = m.d.comb, m.d.sync
-
-        debug = platform.request("debug")
-        
-        # design goes on 12 mhz = 12 * 10^6
-        # 6 khz = 6 * 10^3
-
-        # 2^10 = 10^3
-        # 
-        ctr_tdo = Signal(10)
-        ctr_tdi = Signal(11)
-
-        for x in [ctr_tdo, ctr_tdi]:
-            sync += x.eq(x + 1)
-
-        comb += debug.tms.eq(0)
-
-        with m.If(ctr_tdo == 0):
-            sync += debug.tdo.eq(~debug.tdo)
-        
-        # with m.If(ctr_tdi == 0):
-        #     sync += debug.tdi.eq(~debug.tdi)
-
-        with m.If(ctr_tdi > 2 ** 9):
-            sync += debug.tdi.eq(1)
-        with m.Else():
-            sync += debug.tdi.eq(0)
-
-        return m
 
 def build(elf_path : Path, do_program=True):
     platform = get_platform()
     m = get_board_cpu(elf_path=elf_path)
-    # m = M()
     platform.build(m, do_program=do_program, nextpnr_opts="--timing-allow-fail")
     logger.info(f"OK, Design was built successfully, printing out some stats..")
     timing_report = Path("build/top.tim")

--- a/mtkcpu/cli/top.py
+++ b/mtkcpu/cli/top.py
@@ -53,9 +53,21 @@ def get_platform() -> Platform:
     # Yes that means that the pins at the edge of the board come first
     # and the pins further away from the edge second
     platform.add_resources([
-        Resource("debug", 0, Pins("7 8 9 10 1 2 3 4", dir="o",
-                                    conn=("pmod", 0)), Attrs(IO_STANDARD="SB_LVCMOS"))
+        Resource(
+            "debug",
+            0,
+            Pins(
+                "1 2 3 4 7 8 9 10 ",
+                dir="o",
+                conn=("pmod", 1)),
+                Attrs(IO_STANDARD="SB_LVCMOS")
+            ),
     ])
+
+    # TMS - white - 1
+    # TDI - gray - 2
+    # TDO - purple - 3
+    # TCK - blue - 4
 
     return platform
     

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -118,7 +118,6 @@ class JTAGTap(Elaboratable):
 
         with m.FSM() as self.jtag_fsm:
             with m.State("TEST-LOGIC-RESET"):
-        
                 with m.If(rising_tck & ~tms):
                     sync += self.ir.eq(self.ir_reset)
                     m.next = "RUN-TEST-IDLE"
@@ -163,7 +162,6 @@ class JTAGTap(Elaboratable):
                     m.next = "EXIT1-DR"
 
             with m.State("EXIT1-DR"):
-                # sync += self.port.tdo.eq(0) # TODO
                 with m.If(rising_tck):
                     with m.If(tms):
                         m.next = "UPDATE-DR"
@@ -220,7 +218,6 @@ class JTAGTap(Elaboratable):
                     m.next = "EXIT1-IR"
 
             with m.State("EXIT1-IR"):
-                # sync += self.port.tdo.eq(0) # TODO
                 with m.If(rising_tck):
                     with m.If(tms):
                         m.next = "UPDATE-IR"
@@ -242,21 +239,4 @@ class JTAGTap(Elaboratable):
                     with m.Else():
                         m.next = "RUN-TEST-IDLE"
 
-        # if platform is not None:
-        #     led_r = platform.request("led_r")
-        #     led_g = platform.request("led_g")
-        #     # with m.If(self.rising_tck):
-        #     #     sync += self.port.tdo.eq(~self.port.tdo)
-        #     # sync += self.port.tdo.eq(1)
-        #     with m.FSM() as f:
-        #         with m.State("A"):
-        #             with m.If(~self.jtag_fsm.ongoing("TEST-LOGIC-RESET")):
-        #             # with m.If(debug.tms | debug.tdi | debug.tck):
-        #                 sync += led_g.eq(1)
-        #                 sync += led_r.eq(1)
-        #         #         m.next = "B"
-        #         # with m.State("B"):
-        #         #     with m.If(~debug.tck):
-        #         #         sync += led_r.eq(1)
-                
         return m

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -165,7 +165,7 @@ class JTAGTap(Elaboratable):
                     m.next = "EXIT1-DR"
 
             with m.State("EXIT1-DR"):
-                sync += self.port.tdo.eq(0) # TODO
+                # sync += self.port.tdo.eq(0) # TODO
                 with m.If(rising_tck):
                     with m.If(tms):
                         m.next = "UPDATE-DR"
@@ -222,7 +222,7 @@ class JTAGTap(Elaboratable):
                     m.next = "EXIT1-IR"
 
             with m.State("EXIT1-IR"):
-                sync += self.port.tdo.eq(0) # TODO
+                # sync += self.port.tdo.eq(0) # TODO
                 with m.If(rising_tck):
                     with m.If(tms):
                         m.next = "UPDATE-IR"

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -242,11 +242,17 @@ class JTAGTap(Elaboratable):
                         m.next = "SELECT-IR-SCAN"
                     with m.Else():
                         m.next = "RUN-TEST-IDLE"
-        
 
         if platform is not None:
             led_r = platform.request("led_r")
-            with m.If(self.port.tck):
-                sync += led_r.eq(1)
+            led_g = platform.request("led_g")
+            with m.FSM() as f:
+                with m.State("A"):
+                    with m.If(self.port.tck):
+                        sync += led_g.eq(1)
+                        m.next = "B"
+                with m.State("B"):
+                    with m.If(~self.port.tck):
+                        sync += led_r.eq(1)
                 
         return m

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -90,7 +90,7 @@ class JTAGTap(Elaboratable):
         self.rising_tck = rising_tck = Signal()
         self.falling_tck = falling_tck = Signal()
 
-        sync += prev_tck.eq(self.port.tck)
+        sync += prev_tck.eq(tck)
 
         comb += [
             rising_tck.eq((~prev_tck) & tck),
@@ -118,8 +118,6 @@ class JTAGTap(Elaboratable):
 
         with m.FSM() as self.jtag_fsm:
             with m.State("TEST-LOGIC-RESET"):
-
-                sync += self.port.tdo.eq(1)
         
                 with m.If(rising_tck & ~tms):
                     sync += self.ir.eq(self.ir_reset)

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -63,6 +63,14 @@ class JTAGTap(Elaboratable):
         sync = m.d.sync
         comb = m.d.comb
 
+        debug = platform.request("debug")
+        comb += [
+            self.port.tms.eq(debug[0]),
+            self.port.tdi.eq(debug[1]),
+            debug[2].eq(self.port.tdo),
+            self.port.tck.eq(debug[3]),
+        ]
+
         # XXX it does nothing but draws a horizontal bar on waveform..
         self.BAR = Signal()
         sync += self.BAR.eq(~self.BAR)
@@ -233,5 +241,10 @@ class JTAGTap(Elaboratable):
                         m.next = "SELECT-IR-SCAN"
                     with m.Else():
                         m.next = "RUN-TEST-IDLE"
+        
+
+        led_r = platform.request("led_r")
+        with m.If(~self.jtag_fsm.ongoing("TEST-LOGIC-RESET")):
+            sync += led_r.eq(1)
                 
         return m

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -242,21 +242,21 @@ class JTAGTap(Elaboratable):
                     with m.Else():
                         m.next = "RUN-TEST-IDLE"
 
-        if platform is not None:
-            led_r = platform.request("led_r")
-            led_g = platform.request("led_g")
-            # with m.If(self.rising_tck):
-            #     sync += self.port.tdo.eq(~self.port.tdo)
-            # sync += self.port.tdo.eq(1)
-            with m.FSM() as f:
-                with m.State("A"):
-                    with m.If(~self.jtag_fsm.ongoing("TEST-LOGIC-RESET")):
-                    # with m.If(debug.tms | debug.tdi | debug.tck):
-                        sync += led_g.eq(1)
-                        sync += led_r.eq(1)
-                #         m.next = "B"
-                # with m.State("B"):
-                #     with m.If(~debug.tck):
-                #         sync += led_r.eq(1)
+        # if platform is not None:
+        #     led_r = platform.request("led_r")
+        #     led_g = platform.request("led_g")
+        #     # with m.If(self.rising_tck):
+        #     #     sync += self.port.tdo.eq(~self.port.tdo)
+        #     # sync += self.port.tdo.eq(1)
+        #     with m.FSM() as f:
+        #         with m.State("A"):
+        #             with m.If(~self.jtag_fsm.ongoing("TEST-LOGIC-RESET")):
+        #             # with m.If(debug.tms | debug.tdi | debug.tck):
+        #                 sync += led_g.eq(1)
+        #                 sync += led_r.eq(1)
+        #         #         m.next = "B"
+        #         # with m.State("B"):
+        #         #     with m.If(~debug.tck):
+        #         #         sync += led_r.eq(1)
                 
         return m

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -118,6 +118,9 @@ class JTAGTap(Elaboratable):
 
         with m.FSM() as self.jtag_fsm:
             with m.State("TEST-LOGIC-RESET"):
+
+                sync += self.port.tdo.eq(1)
+        
                 with m.If(rising_tck & ~tms):
                     sync += self.ir.eq(self.ir_reset)
                     m.next = "RUN-TEST-IDLE"

--- a/mtkcpu/units/debug/jtag.py
+++ b/mtkcpu/units/debug/jtag.py
@@ -62,14 +62,15 @@ class JTAGTap(Elaboratable):
         m = Module()
         sync = m.d.sync
         comb = m.d.comb
-
-        debug = platform.request("debug")
-        comb += [
-            self.port.tms.eq(debug[0]),
-            self.port.tdi.eq(debug[1]),
-            debug[2].eq(self.port.tdo),
-            self.port.tck.eq(debug[3]),
-        ]
+        
+        if platform is not None:
+            debug = platform.request("debug")
+            comb += [
+                self.port.tms.eq(debug.tms),
+                self.port.tdi.eq(debug.tdi),
+                debug.tdo.eq(self.port.tdo),
+                self.port.tck.eq(debug.tck),
+            ]
 
         # XXX it does nothing but draws a horizontal bar on waveform..
         self.BAR = Signal()
@@ -243,8 +244,9 @@ class JTAGTap(Elaboratable):
                         m.next = "RUN-TEST-IDLE"
         
 
-        led_r = platform.request("led_r")
-        with m.If(~self.jtag_fsm.ongoing("TEST-LOGIC-RESET")):
-            sync += led_r.eq(1)
+        if platform is not None:
+            led_r = platform.request("led_r")
+            with m.If(self.port.tck):
+                sync += led_r.eq(1)
                 
         return m

--- a/mtkcpu/units/loadstore.py
+++ b/mtkcpu/units/loadstore.py
@@ -225,18 +225,10 @@ class MemoryArbiter(Elaboratable, AddressManager):
 
         from mtkcpu.units.mmio.uart import UartTX
         from amaranth.hdl.rec import Layout
-        from amaranth import Const
 
         def uart_gen_serial_record(platform : Platform, m : Module):
             if platform:
                 serial = platform.request("uart")
-                debug = platform.request("debug")
-                m.d.comb += [
-                    debug.eq(Cat(
-                        serial.tx,
-                        Const(0, 1), # GND
-                    ))
-                ]
             else:
                 serial = Record(Layout([("tx", 1)]), name="UART_SERIAL")
             self.serial = serial # TODO this is obfuscated, but we need those signals for simulation testbench

--- a/mtkcpu/units/loadstore.py
+++ b/mtkcpu/units/loadstore.py
@@ -253,15 +253,15 @@ class MemoryArbiter(Elaboratable, AddressManager):
         )
 
         self.mmio_cfg = [
-            (
-                UartTX(serial_record_gen=uart_gen_serial_record, clk_freq=12_000_000, baud_rate=115200),
-                MMIOAddressSpace(
-                    ws=self.word_size,
-                    basename="uart",
-                    first_valid_addr_incl=0x7000_0000,
-                    last_valid_addr_excl=0x7000_1000,
-                )
-            ),
+            # (
+            #     UartTX(serial_record_gen=uart_gen_serial_record, clk_freq=12_000_000, baud_rate=115200),
+            #     MMIOAddressSpace(
+            #         ws=self.word_size,
+            #         basename="uart",
+            #         first_valid_addr_incl=0x7000_0000,
+            #         last_valid_addr_excl=0x7000_1000,
+            #     )
+            # ),
             (
                 EBR_Wishbone(self.mem_config),
                 MMIOAddressSpace(
@@ -271,15 +271,15 @@ class MemoryArbiter(Elaboratable, AddressManager):
                     last_valid_addr_excl=self.mem_config.last_valid_addr_excl,
                 )
             ),
-            (
-                GPIO_Wishbone(signal_map_gen=gpio_gen),
-                MMIOAddressSpace(
-                    ws=self.word_size,
-                    basename="gpio",
-                    first_valid_addr_incl=0x9000_0000,
-                    last_valid_addr_excl=0x9000_1000,
-                )
-            ),
+            # (
+            #     GPIO_Wishbone(signal_map_gen=gpio_gen),
+            #     MMIOAddressSpace(
+            #         ws=self.word_size,
+            #         basename="gpio",
+            #         first_valid_addr_incl=0x9000_0000,
+            #         last_valid_addr_excl=0x9000_1000,
+            #     )
+            # ),
             (
                 EBR_Wishbone(debug_mem_config),
                 MMIOAddressSpace(

--- a/mtkcpu/units/loadstore.py
+++ b/mtkcpu/units/loadstore.py
@@ -271,15 +271,15 @@ class MemoryArbiter(Elaboratable, AddressManager):
                     last_valid_addr_excl=self.mem_config.last_valid_addr_excl,
                 )
             ),
-            # (
-            #     GPIO_Wishbone(signal_map_gen=gpio_gen),
-            #     MMIOAddressSpace(
-            #         ws=self.word_size,
-            #         basename="gpio",
-            #         first_valid_addr_incl=0x9000_0000,
-            #         last_valid_addr_excl=0x9000_1000,
-            #     )
-            # ),
+            (
+                GPIO_Wishbone(signal_map_gen=gpio_gen),
+                MMIOAddressSpace(
+                    ws=self.word_size,
+                    basename="gpio",
+                    first_valid_addr_incl=0x9000_0000,
+                    last_valid_addr_excl=0x9000_1000,
+                )
+            ),
             (
                 EBR_Wishbone(debug_mem_config),
                 MMIOAddressSpace(

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -14,7 +14,7 @@ ftdi_layout_init 0x2088 0x308b
 ftdi_layout_signal nSRST -data 0x2000 -noe 0x1000
 
 #jtag_rclk
-adapter speed 5
+adapter speed 50
 transport select jtag
 
 set _CHIPNAME riscv

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -18,7 +18,7 @@ adapter speed 2
 transport select jtag
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 7 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 gdb_report_data_abort enable

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -14,7 +14,7 @@ ftdi_layout_init 0x2088 0x308b
 ftdi_layout_signal nSRST -data 0x2000 -noe 0x1000
 
 #jtag_rclk
-adapter speed 2
+adapter_khz 100
 transport select jtag
 
 set _CHIPNAME riscv

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -1,0 +1,25 @@
+
+#
+# Digilent JTAG-HS3
+#
+
+interface ftdi
+ftdi_vid_pid 0x0403 0x6014
+ftdi_device_desc "Digilent USB Device"
+
+# From Digilent support:
+# The SRST pin is [...] 0x20 and 0x10 is the /OE (active low output enable)
+
+ftdi_layout_init 0x2088 0x308b
+ftdi_layout_signal nSRST -data 0x2000 -noe 0x1000
+
+#jtag_rclk
+adapter speed 100
+transport select jtag
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+gdb_report_data_abort enable
+

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -5,7 +5,7 @@
 
 interface ftdi
 ftdi_vid_pid 0x0403 0x6014
-ftdi_device_desc "Digilent USB Device"
+# ftdi_device_desc "Digilent USB Device"
 
 # From Digilent support:
 # The SRST pin is [...] 0x20 and 0x10 is the /OE (active low output enable)
@@ -14,7 +14,7 @@ ftdi_layout_init 0x2088 0x308b
 ftdi_layout_signal nSRST -data 0x2000 -noe 0x1000
 
 #jtag_rclk
-adapter speed 100
+adapter speed 5
 transport select jtag
 
 set _CHIPNAME riscv

--- a/openocd_diligent
+++ b/openocd_diligent
@@ -14,11 +14,11 @@ ftdi_layout_init 0x2088 0x308b
 ftdi_layout_signal nSRST -data 0x2000 -noe 0x1000
 
 #jtag_rclk
-adapter speed 50
+adapter speed 2
 transport select jtag
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 7 -expected-id 0x10e31913
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 gdb_report_data_abort enable


### PR DESCRIPTION
### NOTE: The MR temporarily disables UART, due to resources shortage, on Icebreaker board! (till the time it's cut down)