### PR TITLE
add CPU+ELF simulation with UART TX->stdout.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           ./docker_run.py --cmd 'poetry run mtkcpu/cli/top.py gen_linker_script'
           ./docker_run.py --cmd 'make -B -C sw/uart_tx'
           bash -c 'timeout 30 ./docker_run.py --cmd "poetry run ./mtkcpu/cli/top.py sim -e sw/uart_tx/build/uart_tx.elf" || true' | tee log.txt
-          cat log.txt
           grep -q "Hello from mtkCPU" log.txt
 
       - name: Run OCD tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,28 @@ jobs:
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
+
       - name: Build the Docker image
         shell: bash
         run: make build-docker
+
       - name: Run unit tests
         shell: bash
         run: make unit-test-docker
+
+      - name: Run simulation with UART on stdout
+        shell: bash
+        run: |
+          ./docker_run.py --cmd 'poetry run mtkcpu/cli/top.py gen_linker_script'
+          ./docker_run.py --cmd 'make -B -C sw/uart_tx'
+          bash -c 'timeout 30 ./docker_run.py --cmd "poetry run ./mtkcpu/cli/top.py sim -e sw/uart_tx/build/uart_tx.elf" || true' | tee log.txt
+          cat log.txt
+          grep -q "Hello from mtkCPU" log.txt
+
       - name: Run OCD tests
         shell: bash
         run: make test-ocd-gdb-docker
+
       - name: Synthesisze SoC
         shell: bash
         run: |

--- a/docker_run.py
+++ b/docker_run.py
@@ -53,6 +53,7 @@ def main(cmd : Optional[str]):
 
     command = f"""
 docker run \
+--init --tty \
 --net host \
 {construct_groups_params()} \
 -v {Path(__file__).parent}/sw:/toolchain/sw \

--- a/mtkcpu/cli/top.py
+++ b/mtkcpu/cli/top.py
@@ -94,8 +94,12 @@ def sim(elf_path : Optional[Path], cpu_config: CPU_Config, timeout_cycles: Optio
             bus_cyc = yield bus.cyc
             if bus_cyc and not prev_bus_cyc:
                 # transaction initiated
-                tx_byte = (yield bus.dat_w) & 0xff
-                print(chr(tx_byte), end="")
+                adr = yield bus.adr
+                mask = yield bus.we
+                # origin of those magic constants is 'handle_transaction' method of UartTX block.
+                if (adr == 0x8) and (mask & 1):
+                    tx_byte = (yield bus.dat_w) & 0xff
+                    print(chr(tx_byte), end="")
             prev_bus_cyc = bus_cyc
             yield
 


### PR DESCRIPTION
invocation:
```
./mtkcpu/cli/top.py sim -e sw/uart_tx/build/uart_tx.elf
```

expected output:
```
...
/home/m.bieganski/github/mtkcpu/mtkcpu/units/csr/csr.py:78: DriverConflict: Signal '(sig $signal)' is driven from multiple fragments: top, top.<unnamed #11>; hierarchy will be flattened
  reg_constructor(my_reg_latch=Signal(32, reset=reg_constructor.const()))
/home/m.bieganski/github/mtkcpu/mtkcpu/units/csr/csr.py:78: DriverConflict: Signal '(sig $signal)' is driven from multiple fragments: top, top.<unnamed #12>; hierarchy will be flattened
  reg_constructor(my_reg_latch=Signal(32, reset=reg_constructor.const()))
starting UART tx..
Hello from mtkCPU!
```

`Hello from mtkCPU!` will be printed only once, as it has `1000ms` sleep in between by default.